### PR TITLE
CocoaPods support

### DIFF
--- a/LispCore.podspec
+++ b/LispCore.podspec
@@ -12,6 +12,9 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.15'
 
   s.source_files = 'Sources/LispCore/**/*.swift'
-
+  s.resource_bundles = {
+    'LispCore_LispCore' => ['Sources/LispCore/Resources/**/*.*']
+  }
+  
   s.swift_version = '5.3'
 end

--- a/LispCore.podspec
+++ b/LispCore.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name = 'LispMac'
+  s.name = 'LispCore'
   s.version = '0.1.0'
   s.license = 'MIT'
   s.summary = 'Common Lisp interpreter for macOS and iOS.'

--- a/LispMac.podspec
+++ b/LispMac.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |s|
+  s.name = 'LispMac'
+  s.version = '0.1.0'
+  s.license = 'MIT'
+  s.summary = 'Common Lisp interpreter for macOS and iOS.'
+  s.homepage = 'https://github.com/puliaiev/LispMac'
+  s.authors = { 'Serhii Puliaiev' => 'http://puliaiev.com' }
+  s.social_media_url = 'https://twitter.com/spuliaiev'
+  s.source = { :git => 'https://github.com/puliaiev/LispMac.git', :tag => '0.1.0' }
+
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.15'
+
+  s.source_files = 'Sources/LispCore/**/*.swift'
+
+  s.swift_version = '5.3'
+end

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,11 @@ let package = Package(
             name: "LispCore",
             resources: [
                 Resource.copy("Resources/eval.lisp"),
-            ]),
-        .testTarget(name: "LispCoreTests",
-            dependencies: ["LispCore"])
+            ]
+        ),
+        .testTarget(
+            name: "LispCoreTests",
+            dependencies: ["LispCore"]
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,6 @@ let package = Package(
                 Resource.copy("Resources/eval.lisp"),
             ]),
         .testTarget(name: "LispCoreTests",
-                dependencies: ["LispCore"])
+            dependencies: ["LispCore"])
     ]
 )

--- a/Sources/LispCore/custom_resource_bundle_accessor.swift
+++ b/Sources/LispCore/custom_resource_bundle_accessor.swift
@@ -1,0 +1,40 @@
+//
+//  custom_resource_bundle_accessor.swift
+//  SwiftLisp
+//
+//  Created by Roman Podymov on 10/21/20.
+//  Copyright © 2020 Roman Podymov. All rights reserved.
+//
+
+import Foundation
+
+#if SWIFT_PACKAGE
+#else
+private class BundleFinder {}
+
+extension Foundation.Bundle {
+    /// Returns the resource bundle associated with the current Swift module.
+    static var module: Bundle = {
+        let bundleName = "LispCore_LispCore"
+
+        let candidates = [
+            // Bundle should be present here when the package is linked into an App.
+            Bundle.main.resourceURL,
+
+            // Bundle should be present here when the package is linked into a framework.
+            Bundle(for: BundleFinder.self).resourceURL,
+
+            // For command-line tools.
+            Bundle.main.bundleURL,
+        ]
+
+        for candidate in candidates {
+            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                return bundle
+            }
+        }
+        fatalError("unable to find bundle named LispCore_LispCore")
+    }()
+}
+#endif

--- a/Sources/LispCore/custom_resource_bundle_accessor.swift
+++ b/Sources/LispCore/custom_resource_bundle_accessor.swift
@@ -1,6 +1,6 @@
 //
 //  custom_resource_bundle_accessor.swift
-//  SwiftLisp
+//  LispMac
 //
 //  Created by Roman Podymov on 10/21/20.
 //  Copyright © 2020 Roman Podymov. All rights reserved.


### PR DESCRIPTION
Hello.
Thank you for LispMac.
Added CocoaPods support. **custom_resource_bundle_accessor.swift** is the same as **resource_bundle_accessor.swift** generated by SPM.